### PR TITLE
Log the exceptions caught instead of masking the error

### DIFF
--- a/lambda/copy_snapshots_dest_rds/lambda_function.py
+++ b/lambda/copy_snapshots_dest_rds/lambda_function.py
@@ -66,9 +66,9 @@ def lambda_handler(event, context):
                     try:
                         copy_local(shared_identifier, shared_attributes)
 
-                    except Exception:
+                    except Exception as e:
                         pending_copies += 1
-                        logger.error('Local copy pending: %s' % shared_identifier)
+                        logger.error('Local copy pending: %s (%s)' % (shared_identifier, e))
 
                     else:
                         if REGION != DESTINATION_REGION:
@@ -88,10 +88,10 @@ def lambda_handler(event, context):
                 try:
                     copy_remote(shared_identifier, own_snapshots[shared_identifier])
 
-                except Exception:
+                except Exception as e:
                     pending_copies += 1
-                    logger.error('Remote copy pending: %s: %s' % (
-                        shared_identifier, own_snapshots[shared_identifier]['Arn']))
+                    logger.error('Remote copy pending: %s: %s (%s)' % (
+                        shared_identifier, own_snapshots[shared_identifier]['Arn'], e))
             else:
                 pending_copies += 1
                 logger.error('Remote copy pending: %s: %s' % (

--- a/lambda/copy_snapshots_no_x_account_rds/lambda_function.py
+++ b/lambda/copy_snapshots_no_x_account_rds/lambda_function.py
@@ -69,10 +69,10 @@ def lambda_handler(event, context):
                         try:
                             copy_remote(source_identifier, own_snapshots_encryption[source_identifier])
                  
-                        except Exception:
+                        except Exception as e:
                             pending_copies += 1
-                            logger.error('Remote copy pending: %s: %s' % (
-                                source_identifier, source_snapshots[source_identifier]['Arn']))
+                            logger.error('Remote copy pending: %s: %s (%s)' % (
+                                source_identifier, source_snapshots[source_identifier]['Arn'], e))
                     else:
                         pending_copies += 1
                         logger.error('Remote copy pending: %s: %s' % (

--- a/lambda/delete_old_snapshots_dest_rds/lambda_function.py
+++ b/lambda/delete_old_snapshots_dest_rds/lambda_function.py
@@ -66,9 +66,9 @@ def lambda_handler(event, context):
                         client.delete_db_snapshot(
                             DBSnapshotIdentifier=snapshot)
 
-                    except Exception:
+                    except Exception as e:
                         delete_pending += 1
-                        logger.info('Could not delete %s' % snapshot)
+                        logger.info('Could not delete %s (%s)' % (snapshot, e))
 
                 else:
                     logger.info('Not deleting %s. Only %s days old' %

--- a/lambda/delete_old_snapshots_no_x_account_rds/lambda_function.py
+++ b/lambda/delete_old_snapshots_no_x_account_rds/lambda_function.py
@@ -70,9 +70,9 @@ def lambda_handler(event, context):
                         client.delete_db_snapshot(
                             DBSnapshotIdentifier=snapshot)
 
-                    except Exception:
+                    except Exception as e:
                         delete_pending += 1
-                        logger.info('Could not delete %s' % snapshot)
+                        logger.info('Could not delete %s (%s)' % (snapshot, e))
 
                 else:
                     logger.info('Not deleting %s. Only %s days old' %

--- a/lambda/delete_old_snapshots_rds/lambda_function.py
+++ b/lambda/delete_old_snapshots_rds/lambda_function.py
@@ -60,9 +60,9 @@ def lambda_handler(event, context):
                     client.delete_db_snapshot(
                         DBSnapshotIdentifier=snapshot)
 
-                except Exception:
+                except Exception as e:
                     pending_delete += 1
-                    logger.info('Could not delete %s ' % snapshot)
+                    logger.info('Could not delete %s (%s)' % (snapshot, e))
 
         else: 
             logger.info('Not deleting %s. Created only %s' % (snapshot, days_difference))

--- a/lambda/share_snapshots_rds/lambda_function.py
+++ b/lambda/share_snapshots_rds/lambda_function.py
@@ -59,8 +59,8 @@ def lambda_handler(event, context):
                         DEST_ACCOUNTID
                     ]
                 )
-            except Exception:
-                logger.error('Exception sharing %s' % snapshot_identifier)
+            except Exception as e:
+                logger.error('Exception sharing %s (%s)' % (snapshot_identifier, e))
                 pending_snapshots += 1
 
     if pending_snapshots > 0:

--- a/lambda/take_snapshots_rds/lambda_function.py
+++ b/lambda/take_snapshots_rds/lambda_function.py
@@ -76,8 +76,9 @@ def lambda_handler(event, context):
                     Tags=[{'Key': 'CreatedBy', 'Value': 'Snapshot Tool for RDS'}, {
                         'Key': 'CreatedOn', 'Value': timestamp_format}, {'Key': 'shareAndCopy', 'Value': 'YES'}]
                 )
-            except Exception:
+            except Exception as e:
                 pending_backups += 1
+                logger.info('Could not create snapshot %s (%s)' % (snapshot_identifier, e))
         else:
 
             backup_age = get_latest_snapshot_ts(


### PR DESCRIPTION
When debugging an issue I had to manually patch the lambdas to get the actual error returned by the RDS API.