### PR TITLE
Limits snapshot parsing to manual snapshots only.

### DIFF
--- a/lambda/share_snapshots_rds/lambda_function.py
+++ b/lambda/share_snapshots_rds/lambda_function.py
@@ -40,7 +40,7 @@ logger.setLevel(LOGLEVEL.upper())
 def lambda_handler(event, context):
     pending_snapshots = 0
     client = boto3.client('rds', region_name=REGION)
-    response = paginate_api_call(client, 'describe_db_snapshots', 'DBSnapshots')
+    response = paginate_api_call(client, 'describe_db_snapshots', 'DBSnapshots', SnapshotType='manual')
     filtered = get_own_snapshots_source(PATTERN, response)
 
     # Search all snapshots for the correct tag


### PR DESCRIPTION
*Issue #, if available:* #38 

*Description of changes:*

Adds the `SnapshotType` parameter with value `'manual'` to the call to `describe_db_cluster_snapshots` in order to avoid processing automated snapshots.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
