### PR TITLE
Conditionally create log group of DeleteOldSnapshotsDestRDS lambda function

### DIFF
--- a/cftemplates/snapshots_tool_rds_dest.json
+++ b/cftemplates/snapshots_tool_rds_dest.json
@@ -596,6 +596,7 @@
 		"cwloggroupDeleteOldSnapshotsDestRDS":{
 			"Type": "AWS::Logs::LogGroup",
 			"Description": "Log group for the lambdaCopySnapshotsRDS function's logs",
+			"Condition": "DeleteOld",
 			"DependsOn": "lambdaDeleteOldDestRDS",
 			"Properties": {
 				"RetentionInDays": { "Ref": "LambdaCWLogRetention" }, 


### PR DESCRIPTION
Added condition to cwloggroupDeleteOldSnapshotsDestRDS to check if DeleteOld parameter is set to TRUE. 
Lambda function referenced by cwloggroupDeleteOldSnapshotsDestRDS would not exist if DeleteOld is set to FALSE cause CloudFormation stack to break during creation.

*Issue #, if available:*

*Description of changes:*
Added condition to cwloggroupDeleteOldSnapshotsDestRDS to check if DeleteOld parameter is set to TRUE. 
Lambda function referenced by cwloggroupDeleteOldSnapshotsDestRDS would not exist if DeleteOld is set to FALSE cause CloudFormation stack to break during creation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
