### PR TITLE
Ignore in-progress snapshots when parsing

### DIFF
--- a/lambda/snapshots_tool_utils.py
+++ b/lambda/snapshots_tool_utils.py
@@ -203,6 +203,10 @@ def get_own_snapshots_source(pattern, response, backup_interval=None):
     filtered = {}
 
     for snapshot in response['DBSnapshots']:
+        
+        # No need to consider snapshots that are still in progress
+        if 'SnapshotCreateTime' not in snapshot:
+            continue
 
         # No need to get tags for snapshots outside of the backup interval
         if backup_interval and snapshot['SnapshotCreateTime'].replace(tzinfo=None) < datetime.utcnow().replace(tzinfo=None) - timedelta(hours=backup_interval):


### PR DESCRIPTION
*Issue #, if available:* #45

*Description of changes:* Do not include snapshots that are in progress (and hence have no SnapshotCreateTime) when parsing snapshots, in order to avoid throwing errors.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
