### PR TITLE
Fix mixed indents on cftemplates

### DIFF
--- a/cftemplates/snapshots_tool_rds_dest.json
+++ b/cftemplates/snapshots_tool_rds_dest.json
@@ -57,11 +57,11 @@
 			"Default": "TRUE",
 			"Description": "Enable copying snapshots across accounts. Set to FALSE if your source snapshosts are not on a different account"
 		},
-                "LogGroupName": {
-                        "Type": "String",
-                        "Default": "lambdaDeleteOldSnapshotsRDS-dest",
-                        "Description": "Name for RDS snapshot log group."
-                }
+		"LogGroupName": {
+			"Type": "String",
+			"Default": "lambdaDeleteOldSnapshotsRDS-dest",
+			"Description": "Name for RDS snapshot log group."
+		}
 	},
 	"Conditions": {
 		"DefaultBucket": {

--- a/cftemplates/snapshots_tool_rds_source.json
+++ b/cftemplates/snapshots_tool_rds_source.json
@@ -63,11 +63,11 @@
 			"Description": "Set to TRUE to filter instances that have tag CopyDBSnapshot set to True. Set to FALSE to disable",
 			"AllowedValues": ["TRUE", "FALSE"]
 		},
-                "LogGroupName": {
-                        "Type": "String",
-                        "Default": "lambdaDeleteOldSnapshotsRDS-source",
-                        "Description": "Name for RDS snapshot log group."
-                }
+		"LogGroupName": {
+			"Type": "String",
+			"Default": "lambdaDeleteOldSnapshotsRDS-source",
+			"Description": "Name for RDS snapshot log group."
+		}
 	},
 	"Conditions": {
 		"Share": {


### PR DESCRIPTION
*Description of changes:*
snapshots_tool_rds_dest.json and snapshots_tool_rds_source.json have a mix of spaces and tabs used for indentation. This converts the only instance of spaces to Tabs to ensure consistency.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.