### PR TITLE
Fixed missing RDS permissions

### DIFF
--- a/cftemplates/snapshots_tool_rds_dest.json
+++ b/cftemplates/snapshots_tool_rds_dest.json
@@ -260,7 +260,8 @@
 									"rds:ModifyDBSnapshotAttribute",
 									"rds:DescribeDBSnapshotAttributes",
 									"rds:CopyDBSnapshot",
-									"rds:ListTagsForResource"
+									"rds:ListTagsForResource",
+									"rds:AddTagsToResource"
 								],
 								"Resource": "*"
 							}]

--- a/cftemplates/snapshots_tool_rds_source.json
+++ b/cftemplates/snapshots_tool_rds_source.json
@@ -298,7 +298,8 @@
 									"rds:DescribeDBSnapshots",
 									"rds:ModifyDBSnapshotAttribute",
 									"rds:DescribeDBSnapshotAttributes",
-									"rds:ListTagsForResource"
+									"rds:ListTagsForResource",
+									"rds:AddTagsToResource"
 								],
 								"Resource": "*"
 							}]


### PR DESCRIPTION
*Issue #, if available:*

Tracked via Issue #62 

*Description of changes:*

Added `"rds:AddTagsToResource"` to the `inline_policy_snapshots_rds` IAM policy as it was failing for lack of permission.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
