### PR TITLE
cwEventCopySnapshotsRDS: use valid cron expression

### DIFF
--- a/cftemplates/snapshots_tool_rds_dest.json
+++ b/cftemplates/snapshots_tool_rds_dest.json
@@ -507,7 +507,7 @@
 			"Properties": {
 				"Description": "Triggers the RDS Copy state machine in the destination account",
 				"ScheduleExpression": {
-					"Fn::Join": ["", ["cron(", "/30 * * * ? *", ")"]]
+					"Fn::Join": ["", ["cron(", "*/30 * * * ? *", ")"]]
 				},
 				"State": "ENABLED",
 				"Targets": [{

--- a/cftemplates/snapshots_tool_rds_dest.json
+++ b/cftemplates/snapshots_tool_rds_dest.json
@@ -527,7 +527,7 @@
 			"Properties": {
 				"Description": "Triggers the RDS DeleteOld state machine in the destination account",
 				"ScheduleExpression": {
-					"Fn::Join": ["", ["cron(", "0 /1 * * ? *", ")"]]
+					"Fn::Join": ["", ["cron(", "0 */1 * * ? *", ")"]]
 				},
 				"State": "ENABLED",
 				"Targets": [{


### PR DESCRIPTION
*Issue #, if available:*

After applying the destination template to the account, the following scheduling error is observable in the cwEventCopySnapshotsRDS events configuration:

![image](https://user-images.githubusercontent.com/991850/222513186-c133cf5d-af82-400d-874d-dbe9d840abcd.png)

The same can be seen for the `cwEventDeleteOldSnapshotRDS` expression:

![image](https://user-images.githubusercontent.com/991850/222513896-06f9567d-3367-41a3-ad6e-5f1aacd9d362.png)

*Description of changes:*

- Add missing `*` to cron expression resulting in the `cwEventCopySnapshotsRDS` event running on the expected 30 minute interval
- Add missing `*` character causing the `cwEventDeleteOldSnapshotRDS` cron expression to run on the expected 1 hour interval 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
